### PR TITLE
20人以上チャート生成するときのエラー発生を修復

### DIFF
--- a/chart_python.py
+++ b/chart_python.py
@@ -144,3 +144,4 @@ def draw_chart(import_data):
     wb.save('out.xlsx')
     # pil_img = Image.fromarray(plt.savefig('graph.png'))
     # pil_img.save('data/dst/lena_square_save.png')
+    plt.close()


### PR DESCRIPTION
plt.close()をしていないせいで、20人以上のチャート生成時にエラーがでるため、plt.close()するようにした